### PR TITLE
Fix panic on Windows when lazyDependency returns null

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,7 +65,7 @@ pub fn build(b: *std.Build) void {
         .link_libcpp = true,
     });
 
-    const wgpu_dep = b.lazyDependency(target_name, .{}).?;
+    const wgpu_dep = b.lazyDependency(target_name, .{}) orelse return;
 
     const lib_name = switch (target_res.os.tag) {
         // There's also some sorf of .pdb file available, which I think is a database of debugging symbols.


### PR DESCRIPTION
It turns out, on Windows (possibly other systems as well), when you use lazy dependencies the `build` function gets called twice.  The first time, it fetches the dependencies, and the second time it has them loaded up and you can put them to use. According to the docs:
> if this function returns null it means that the only purpose of completing the configure phase is to find out all the other lazy dependencies that are also required.

So, I think we can safely return here and rely on the dependencies being present the next time the build function is run.