### PR TITLE
Fix windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const wgpu_native_dep = b.dependency("wgpu_native_zig", .{
   .target = target
 });
 ```
+An example of using `wgpu-native-zig` on Windows can be found at [wgpu-native-zig-windows-test](https://github.com/bronter/wgpu-native-zig-windows-test).
 ### Dynamic linking
 Dynamic linking can be made to work, though it is a bit messy to use.
 When you initialize your `wgpu_native_dep`, add the option for dynamic linking like so:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Or, specify it with your build command. For example, the triangle example in thi
 ```sh
 zig build run-triangle-example -Dtarget=x86_64-windows-msvc
 ```
+Either way, pass the resolved target to the dependency like so:
+```zig
+const wgpu_native_dep = b.dependency("wgpu_native_zig", .{
+  .target = target
+});
+```
 ### Dynamic linking
 Dynamic linking can be made to work, though it is a bit messy to use.
 When you initialize your `wgpu_native_dep`, add the option for dynamic linking like so:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,43 @@ Then, in `build.zig` add:
     lib.root_module.addImport("wgpu", wgpu_native_dep.module("wgpu"));
 ```
 
+### Building on Windows
+For Windows, static linking is currently only supported if using MSVC (this will soon change), so specify that in your build target:
+```zig
+const target = b.standardTargetOptions(.{
+    .default_target = .{
+        .abi = .msvc,
+    }
+});
+```
+Or, specify it with your build command. For example, the triangle example in this repository can be run like so:
+```sh
+zig build run-triangle-example -Dtarget=x86_64-windows-msvc
+```
+### Dynamic linking
+Dynamic linking can be made to work, though it is a bit messy to use.
+When you initialize your `wgpu_native_dep`, add the option for dynamic linking like so:
+```zig
+const wgpu_native_dep = b.dependency("wgpu_native_zig", .{
+  // Defaults to .static if you don't specify
+  .link_mode = .dynamic
+});
+```
+Then add the following with your install step dependencies:
+```zig
+const lib_dir = wgpu_native_dep.namedWriteFiles("lib").getDirectory();
+
+// This would also work with .so files on linux
+const dll_path = lib_dir.join(b.allocator, "wgpu_native.dll") catch return;
+
+// addInstallBinFile puts the dll in the same directory as your executable
+const install_dll = b.addInstallBinFile(dll_path, "wgpu_native.dll");
+
+// Make sure that the dll is installed when the install step is run
+b.getInstallStep().dependOn(&install_dll.step);
+```
+
+
 ## How the `wgpu` module differs from `wgpu-c`
 * Names are shortened to remove redundancy.
   * For example `wgpu.WGPUSurfaceDescriptor` becomes `wgpu.SurfaceDescriptor`
@@ -115,7 +152,6 @@ Then, in `build.zig` add:
   * This pretty much means, it is replaced with `bool` in the parameters and return values of methods, but not in structs or the parameters/return values of procs (which are supposed to be function pointers to things returned by `wgpuGetProcAddress`).
 
 ## TODO
-* Test this on other machines with different OS/CPU (currently only tested on linux x86_64; zig version 0.13.0-dev.351+64ef45eb0)
+* Test this on other machines with different OS/CPU (currently only tested on x86_64-linux-gnu and x86_64-windows-msvc; zig version 0.13.0-dev.351+64ef45eb0)
 * Port [wgpu-native-examples](https://github.com/samdauwe/webgpu-native-examples) using wrapper code, as a basic form of documentation.
 * Custom-build `wgpu-native`; provided all the necessary tools/dependencies are present.
-* Figure out dynamic linking

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const TargetQuery = std.Target.Query;
 const target_whitelist = [_] TargetQuery {
     TargetQuery {
         .cpu_arch = .aarch64,
-        .os_tag = .linux
+        .os_tag = .linux,
     },
     TargetQuery {
         .cpu_arch = .aarch64,
@@ -30,109 +30,135 @@ const target_whitelist = [_] TargetQuery {
     },
 };
 
-// Although this function looks imperative, note that its job is to
-// declaratively construct a build graph that will be executed by an external
-// runner.
-pub fn build(b: *std.Build) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
-    const target = b.standardTargetOptions(.{
-        .whitelist = &target_whitelist,
+const WGPUBuildContext = struct {
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    is_windows: bool,
+    wgpu_dep: *std.Build.Dependency,
+    libwgpu_path: std.Build.LazyPath,
+    install_lib_dir: []const u8,
+    wgpu_mod: *std.Build.Module,
+    wgpu_c_mod: *std.Build.Module,
+
+    fn init(b: *std.Build) ?WGPUBuildContext {
+        // Standard target options allows the person running `zig build` to choose
+        // what target to build for. Here we do not override the defaults, which
+        // means any target is allowed, and the default is native. Other options
+        // for restricting supported target set are available.
+        const target = b.standardTargetOptions(.{
+            .whitelist = &target_whitelist,
+        });
+
+        // Standard optimization options allow the person running `zig build` to select
+        // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+        // set a preferred release mode, allowing the user to decide how to optimize.
+        const optimize = b.standardOptimizeOption(.{});
+
+        const target_res = target.result;
+        const os_str = @tagName(target_res.os.tag);
+        const arch_str = @tagName(target_res.cpu.arch);
+        const mode_str = switch (optimize) {
+            .Debug => "debug",
+            else => "release",
+        };
+        const target_name_slices = [_] [:0]const u8 {"wgpu_", os_str, "_", arch_str, "_", mode_str};
+        const maybe_target_name = std.mem.concatWithSentinel(b.allocator, u8, &target_name_slices, 0);
+        const target_name = maybe_target_name catch "wgpu_linux_x86_64_debug";
+
+        const wgpu_mod = b.addModule("wgpu", .{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libcpp = true,
+        });
+
+        const wgpu_dep = b.lazyDependency(target_name, .{}) orelse return null;
+
+        const translate_step = b.addTranslateC(.{
+            // wgpu.h imports webgpu.h, so we get the contents of both files, as well as a bunch of libc garbage.
+            .root_source_file = wgpu_dep.path("wgpu.h"),
+
+            .target = target,
+            .optimize = optimize,
+        });
+        const wgpu_c_mod = translate_step.addModule("wgpu-c");
+        wgpu_c_mod.resolved_target = target;
+        wgpu_c_mod.link_libcpp = true;
+
+        var libwgpu_path: std.Build.LazyPath = undefined;
+        var is_windows: bool = false;
+
+        switch(target_res.os.tag) {
+            .windows => {
+                is_windows = true;
+                libwgpu_path = wgpu_dep.path("wgpu_native.dll.lib");
+
+                // TODO: Find out if this propagates through when another module depends on this one; if not we may need to muck about with addNamedWriteFiles/addCopyFile.
+                const dll_install_file = b.addInstallLibFile(wgpu_dep.path("wgpu_native.dll"), "wgpu_native.dll");
+                b.getInstallStep().dependOn(&dll_install_file.step);
+
+                wgpu_mod.addLibraryPath(wgpu_dep.path(""));
+                wgpu_c_mod.addLibraryPath(wgpu_dep.path(""));
+
+                // TODO: I think this has to be done by the thing that uses this module and not by the module itself?
+                // wgpu_mod.linkSystemLibrary("wgpu_native.dll", .{});
+                // wgpu_c_mod.linkSystemLibrary("wgpu_native.dll", .{});
+            },
+            else => {
+                // This only tries to account for linux/macos since we're using pre-compiled wgpu-native;
+                // need to think harder about this if I get custom builds working.
+                libwgpu_path = wgpu_dep.path("libwgpu_native.a");
+            },
+        }
+        wgpu_mod.addObjectFile(libwgpu_path);
+        wgpu_c_mod.addObjectFile(libwgpu_path);
+
+
+        return WGPUBuildContext {
+            .target = target,
+            .optimize = optimize,
+            .is_windows = is_windows,
+            .wgpu_dep = wgpu_dep,
+            .libwgpu_path = libwgpu_path,
+            .install_lib_dir = b.getInstallPath(.lib, ""),
+            .wgpu_mod = wgpu_mod,
+            .wgpu_c_mod = wgpu_c_mod,
+        };
+    }
+};
+
+fn triangle_example(b: *std.Build, context: *const WGPUBuildContext) void {
+    const bmp_mod = b.createModule(.{
+        .root_source_file = b.path("examples/bmp.zig"),
     });
-
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
-    const optimize = b.standardOptimizeOption(.{});
-
-    const target_res = target.result;
-    const os_str = @tagName(target_res.os.tag);
-    const arch_str = @tagName(target_res.cpu.arch);
-    const mode_str = switch (optimize) {
-        .Debug => "debug",
-        else => "release"
-    };
-    const target_name_slices = [_] [:0]const u8 {"wgpu_", os_str, "_", arch_str, "_", mode_str};
-    const maybe_target_name = std.mem.concatWithSentinel(b.allocator, u8, &target_name_slices, 0);
-    const target_name = maybe_target_name catch "wgpu_linux_x86_64_debug";
-
-    const mod = b.addModule("wgpu", .{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-        .link_libcpp = true,
-    });
-
-    const wgpu_dep = b.lazyDependency(target_name, .{}) orelse return;
-
-    const lib_name = switch (target_res.os.tag) {
-        // There's also some sorf of .pdb file available, which I think is a database of debugging symbols.
-        // I don't even have a Windows machine though,
-        // so I'll let somebody who does tell me what it is and if I need it.
-        .windows => "wgpu_native.lib",
-
-        // This only tries to account for linux/macos since we're using pre-compiled wgpu-native;
-        // need to think harder about this if I get custom builds working.
-        else => "libwgpu_native.a",
-    }; // Also these don't even try to account for dynamic linking; that's a problem for future me.
-    const libwgpu_path = wgpu_dep.path(lib_name);
-    mod.addObjectFile(libwgpu_path);
-
-    const translate_step = b.addTranslateC(.{
-        // wgpu.h imports webgpu.h, so we get the contents of both files, as well as a bunch of libc garbage.
-        .root_source_file = wgpu_dep.path("wgpu.h"),
-
-        .target = target,
-        .optimize = optimize,
-    });
-    const wgpu_c_mod = translate_step.addModule("wgpu-c");
-    wgpu_c_mod.addObjectFile(libwgpu_path);
-    wgpu_c_mod.link_libcpp = true;
-
-    // Creates a step for unit testing. This only builds the test executable
-    // but does not run it.
-    const compute_test = b.addTest(.{
-        .name = "compute-test",
-        .root_source_file = b.path("tests/compute.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    compute_test.root_module.addImport("wgpu", mod);
-
-    const run_compute_test = b.addRunArtifact(compute_test);
-
-    const compute_test_c = b.addTest(.{
-        .name = "compute-test-c",
-        .root_source_file = b.path("tests/compute_c.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    compute_test_c.root_module.addImport("wgpu-c", wgpu_c_mod);
-
-    const run_compute_test_c = b.addRunArtifact(compute_test_c);
 
     const triangle_example_exe = b.addExecutable(.{
         .name = "triangle-example",
         .root_source_file = b.path("examples/triangle/triangle.zig"),
-        .target = target,
-        .optimize = optimize,
+        .target = context.target,
+        .optimize = context.optimize,
     });
-    triangle_example_exe.root_module.addImport("wgpu", mod);
-    const bmp_mod = b.createModule(.{
-        .root_source_file = b.path("examples/bmp.zig"),
-    });
+    triangle_example_exe.root_module.addImport("wgpu", context.wgpu_mod);
     triangle_example_exe.root_module.addImport("bmp", bmp_mod);
+
     const run_triangle_cmd = b.addRunArtifact(triangle_example_exe);
+
     const run_triangle_step = b.step("run-triangle-example", "Run the triangle example");
     run_triangle_step.dependOn(&run_triangle_cmd.step);
 
-    // This exposes a `test` step to the `zig build --help` menu,
-    // providing a way for the user to request running the unit tests.
-    const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_compute_test.step);
-    test_step.dependOn(&run_compute_test_c.step);
+    if (context.is_windows) {
+        triangle_example_exe.linkSystemLibrary2("wgpu_native.dll", .{});
+
+        run_triangle_cmd.addPathDir(context.install_lib_dir);
+        run_triangle_step.dependOn(b.getInstallStep());
+    }
+}
+
+fn unit_tests(b: *std.Build, context: *const WGPUBuildContext) void {
+    const unit_test_step = b.step("test", "Run unit tests");
+    if (context.is_windows) {
+        unit_test_step.dependOn(b.getInstallStep());
+    }
 
     const test_files = [_] [:0]const u8 {
         "src/instance.zig",
@@ -149,13 +175,68 @@ pub fn build(b: *std.Build) void {
         const t = b.addTest(.{
             .name = test_name,
             .root_source_file = b.path(test_file),
-            .target = target,
-            .optimize = optimize,
+            .target = context.target,
+            .optimize = context.optimize,
         });
-        t.addObjectFile(libwgpu_path);
+        t.addObjectFile(context.libwgpu_path);
         t.linkLibCpp();
 
         const run_test = b.addRunArtifact(t);
-        test_step.dependOn(&run_test.step);
+
+        if (context.is_windows) {
+            t.addLibraryPath(context.wgpu_dep.path(""));
+            t.linkSystemLibrary2("wgpu_native.dll", .{});
+
+            run_test.addPathDir(context.install_lib_dir);
+        }
+
+        unit_test_step.dependOn(&run_test.step);
     }
+}
+
+fn compute_tests(b: *std.Build, context: *const WGPUBuildContext) void {
+    const compute_test = b.addTest(.{
+        .name = "compute-test",
+        .root_source_file = b.path("tests/compute.zig"),
+        .target = context.target,
+        .optimize = context.optimize,
+    });
+    compute_test.root_module.addImport("wgpu", context.wgpu_mod);
+
+    const run_compute_test = b.addRunArtifact(compute_test);
+
+    const compute_test_c = b.addTest(.{
+        .name = "compute-test-c",
+        .root_source_file = b.path("tests/compute_c.zig"),
+        .target = context.target,
+        .optimize = context.optimize,
+    });
+    compute_test_c.root_module.addImport("wgpu-c", context.wgpu_c_mod);
+
+    const run_compute_test_c = b.addRunArtifact(compute_test_c);
+
+    const compute_test_step = b.step("compute-tests", "Run compute shader tests");
+    if (context.is_windows) {
+        compute_test.linkSystemLibrary2("wgpu_native.dll", .{});
+        compute_test_c.linkSystemLibrary2("wgpu_native.dll", .{});
+
+        run_compute_test.addPathDir(context.install_lib_dir);
+        run_compute_test_c.addPathDir(context.install_lib_dir);
+
+        compute_test_step.dependOn(b.getInstallStep());
+    }
+    compute_test_step.dependOn(&run_compute_test.step);
+    compute_test_step.dependOn(&run_compute_test_c.step);
+}
+
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    const context = WGPUBuildContext.init(b) orelse return;
+
+    compute_tests(b, &context);
+    unit_tests(b, &context);
+
+    triangle_example(b, &context);
 }

--- a/build.zig
+++ b/build.zig
@@ -95,6 +95,8 @@ const WGPUBuildContext = struct {
         // means any target is allowed, and the default is native. Other options
         // for restricting supported target set are available.
         const target = b.standardTargetOptions(.{});
+
+        // TODO: Clean up this target query stuff; I must be missing something because it probably shouldn't be this complicated.
         const target_query = target.query;
         if (!match_target_whitelist(target_query)) {
             std.log.err("chosen target '{s}' does not match one of the allowed targets", .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,7 +7,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.13.0-dev.351+64ef45eb0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/test-all
+++ b/test-all
@@ -1,2 +1,2 @@
 #!/bin/sh
-zig build test --summary all
+zig build test compute-tests --summary all


### PR DESCRIPTION
This should fix https://github.com/bronter/wgpu-native-zig/issues/4 as well as add support for dynamic linking.
On Windows, static linking currently only works with MSVC. This should change when we upgrade the `wgpu-native` dependency since the newer versions support the gnu abi as well. It may take some time since the latest version adds a lot of new targets, so another major refactor of `build.zig` may be in order.

I feel like the experience for dynamic linking could be better as well. It seems that libs added during `wgpu-native-zig`'s install step don't propagate to the final output directory of an app that consumes this lib, and trying to pull them out of `.zig-cache` only works in certain cases and not if you need to copy it to the same directory as your executable.  I may continue to experiment with that. Ideally (in my opinion) somebody using this lib would not have to worry about the `.dll`/`.so` at all and it would automatically get copied to the output directory without having to go into `build.zig` and muck about with `namedWriteFiles`.