### PR TITLE
macos fixes and build script refactor

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -193,9 +193,8 @@ pub fn build(b: *std.Build) void {
     }
     // this is the lazy path to the .dll / .dylib / .so
     // its added for users of this module dependency under the name "lib"
-    // you can get it with `.namedLazyPath("lib")`
+    // you can get it with `.namedLazyPath("libwgpu_native")`
 
-    // NOTE: on windows the objects dont have the "lib" prefix!
     const extension: []const u8 =
         if (link_mode == .static)
             switch (target.result.os.tag) {
@@ -207,6 +206,7 @@ pub fn build(b: *std.Build) void {
             .macos, .ios => "dylib",
             else => "so",
         };
+    // NOTE: on windows the objects from rust dont have the "lib" prefix!
     const prefix = switch (target.result.os.tag) {
         .windows => "",
         else => "lib",

--- a/examples/bmp.zig
+++ b/examples/bmp.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
 pub fn write24BitBMP(file_name: []const u8, comptime width: u32, comptime height: u32, bgra_data: *[width * height * 4]u8) !void {
-    std.fs.cwd().makeDir("examples/output") catch {};
     const file = try std.fs.cwd().createFile(file_name, .{});
     defer file.close();
 

--- a/examples/bmp.zig
+++ b/examples/bmp.zig
@@ -1,16 +1,17 @@
 const std = @import("std");
 
 pub fn write24BitBMP(file_name: []const u8, comptime width: u32, comptime height: u32, bgra_data: *[width * height * 4]u8) !void {
+    std.fs.cwd().makeDir("examples/output") catch {};
     const file = try std.fs.cwd().createFile(file_name, .{});
     defer file.close();
 
     var writer = file.writer();
 
     // ID
-    _ = try writer.write(&[2]u8{'B', 'M'});
+    _ = try writer.write(&[2]u8{ 'B', 'M' });
 
     const colors_per_line = width * 3;
-    const bytes_per_line = switch(colors_per_line & 0x00000003) {
+    const bytes_per_line = switch (colors_per_line & 0x00000003) {
         0 => colors_per_line,
         else => (colors_per_line | 0x00000003) + 1,
     };
@@ -45,7 +46,7 @@ pub fn write24BitBMP(file_name: []const u8, comptime width: u32, comptime height
             const bgra_pixel_offset = line_offset + (x * 4);
             line_buffer[bgr_pixel_offset] = bgra_data[bgra_pixel_offset];
             line_buffer[bgr_pixel_offset + 1] = bgra_data[bgra_pixel_offset + 1];
-            line_buffer[bgr_pixel_offset + 2] = bgra_data[bgra_pixel_offset + 2]; 
+            line_buffer[bgr_pixel_offset + 2] = bgra_data[bgra_pixel_offset + 2];
         }
         _ = try writer.write(&line_buffer);
     }

--- a/examples/triangle/triangle.zig
+++ b/examples/triangle/triangle.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const wgpu = @import("wgpu");
 const bmp = @import("bmp");
 
-const output_extent = wgpu.Extent3D {
+const output_extent = wgpu.Extent3D{
     .width = 640,
     .height = 480,
     .depth_or_array_layers = 1,
@@ -22,17 +22,17 @@ pub fn main() !void {
     const instance = wgpu.Instance.create(null).?;
     defer instance.release();
 
-    const adapter_request = instance.requestAdapterSync(&wgpu.RequestAdapterOptions {}, 0);
-    const adapter = switch(adapter_request.status) {
+    const adapter_request = instance.requestAdapterSync(&wgpu.RequestAdapterOptions{}, 0);
+    const adapter = switch (adapter_request.status) {
         .success => adapter_request.adapter.?,
         else => return error.NoAdapter,
     };
     defer adapter.release();
 
-    const device_request = adapter.requestDeviceSync(instance, &wgpu.DeviceDescriptor {
+    const device_request = adapter.requestDeviceSync(instance, &wgpu.DeviceDescriptor{
         .required_limits = null,
     }, 0);
-    const device = switch(device_request.status) {
+    const device = switch (device_request.status) {
         .success => device_request.device.?,
         else => return error.NoDevice,
     };
@@ -43,7 +43,7 @@ pub fn main() !void {
 
     const swap_chain_format = wgpu.TextureFormat.bgra8_unorm_srgb;
 
-    const target_texture = device.createTexture(&wgpu.TextureDescriptor {
+    const target_texture = device.createTexture(&wgpu.TextureDescriptor{
         .label = wgpu.StringView.fromSlice("Render texture"),
         .size = output_extent,
         .format = swap_chain_format,
@@ -51,7 +51,7 @@ pub fn main() !void {
     }).?;
     defer target_texture.release();
 
-    const target_texture_view = target_texture.createView(&wgpu.TextureViewDescriptor {
+    const target_texture_view = target_texture.createView(&wgpu.TextureViewDescriptor{
         .label = wgpu.StringView.fromSlice("Render texture view"),
         .mip_level_count = 1,
         .array_layer_count = 1,
@@ -62,7 +62,7 @@ pub fn main() !void {
     })).?;
     defer shader_module.release();
 
-    const staging_buffer = device.createBuffer(&wgpu.BufferDescriptor {
+    const staging_buffer = device.createBuffer(&wgpu.BufferDescriptor{
         .label = wgpu.StringView.fromSlice("staging_buffer"),
         .usage = wgpu.BufferUsages.map_read | wgpu.BufferUsages.copy_dst,
         .size = output_size,
@@ -70,16 +70,16 @@ pub fn main() !void {
     }).?;
     defer staging_buffer.release();
 
-    const color_targets = &[_] wgpu.ColorTargetState{
-        wgpu.ColorTargetState {
+    const color_targets = &[_]wgpu.ColorTargetState{
+        wgpu.ColorTargetState{
             .format = swap_chain_format,
-            .blend = &wgpu.BlendState {
-                .color = wgpu.BlendComponent {
+            .blend = &wgpu.BlendState{
+                .color = wgpu.BlendComponent{
                     .operation = .add,
                     .src_factor = .src_alpha,
                     .dst_factor = .one_minus_src_alpha,
                 },
-                .alpha = wgpu.BlendComponent {
+                .alpha = wgpu.BlendComponent{
                     .operation = .add,
                     .src_factor = .zero,
                     .dst_factor = .one,
@@ -88,37 +88,30 @@ pub fn main() !void {
         },
     };
 
-    const pipeline = device.createRenderPipeline(&wgpu.RenderPipelineDescriptor {
-        .vertex = wgpu.VertexState {
+    const pipeline = device.createRenderPipeline(&wgpu.RenderPipelineDescriptor{
+        .vertex = wgpu.VertexState{
             .module = shader_module,
             .entry_point = wgpu.StringView.fromSlice("vs_main"),
         },
-        .primitive = wgpu.PrimitiveState {},
-        .fragment = &wgpu.FragmentState {
-            .module = shader_module,
-            .entry_point = wgpu.StringView.fromSlice("fs_main"),
-            .target_count = color_targets.len,
-            .targets = color_targets.ptr
-        },
-        .multisample = wgpu.MultisampleState {},
+        .primitive = wgpu.PrimitiveState{},
+        .fragment = &wgpu.FragmentState{ .module = shader_module, .entry_point = wgpu.StringView.fromSlice("fs_main"), .target_count = color_targets.len, .targets = color_targets.ptr },
+        .multisample = wgpu.MultisampleState{},
     }).?;
     defer pipeline.release();
 
     { // Mock main "loop"
         const next_texture = target_texture_view;
 
-        const encoder = device.createCommandEncoder(&wgpu.CommandEncoderDescriptor {
+        const encoder = device.createCommandEncoder(&wgpu.CommandEncoderDescriptor{
             .label = wgpu.StringView.fromSlice("Command Encoder"),
         }).?;
         defer encoder.release();
 
-        const color_attachments = &[_]wgpu.ColorAttachment{
-            wgpu.ColorAttachment {
-                .view = next_texture,
-                .clear_value = wgpu.Color {},
-            }
-        };
-        const render_pass = encoder.beginRenderPass(&wgpu.RenderPassDescriptor {
+        const color_attachments = &[_]wgpu.ColorAttachment{wgpu.ColorAttachment{
+            .view = next_texture,
+            .clear_value = wgpu.Color{},
+        }};
+        const render_pass = encoder.beginRenderPass(&wgpu.RenderPassDescriptor{
             .color_attachment_count = color_attachments.len,
             .color_attachments = color_attachments.ptr,
         }).?;
@@ -133,12 +126,12 @@ pub fn main() !void {
 
         defer next_texture.release();
 
-        const img_copy_src = wgpu.TexelCopyTextureInfo {
-            .origin = wgpu.Origin3D {},
+        const img_copy_src = wgpu.TexelCopyTextureInfo{
+            .origin = wgpu.Origin3D{},
             .texture = target_texture,
         };
-        const img_copy_dst = wgpu.TexelCopyBufferInfo {
-            .layout = wgpu.TexelCopyBufferLayout {
+        const img_copy_dst = wgpu.TexelCopyBufferInfo{
+            .layout = wgpu.TexelCopyBufferLayout{
                 .bytes_per_row = output_bytes_per_row,
                 .rows_per_image = output_extent.height,
             },
@@ -147,7 +140,7 @@ pub fn main() !void {
 
         encoder.copyTextureToBuffer(&img_copy_src, &img_copy_dst, &output_extent);
 
-        const command_buffer = encoder.finish(&wgpu.CommandBufferDescriptor {
+        const command_buffer = encoder.finish(&wgpu.CommandBufferDescriptor{
             .label = wgpu.StringView.fromSlice("Command Buffer"),
         }).?;
         defer command_buffer.release();
@@ -155,12 +148,12 @@ pub fn main() !void {
         queue.submit(&[_]*const wgpu.CommandBuffer{command_buffer});
 
         var buffer_map_complete = false;
-        _ = staging_buffer.mapAsync(wgpu.MapModes.read, 0, output_size, wgpu.BufferMapCallbackInfo {
+        _ = staging_buffer.mapAsync(wgpu.MapModes.read, 0, output_size, wgpu.BufferMapCallbackInfo{
             .callback = handleBufferMap,
             .userdata1 = @ptrCast(&buffer_map_complete),
         });
         instance.processEvents();
-        while(!buffer_map_complete) {
+        while (!buffer_map_complete) {
             instance.processEvents();
         }
         // _ = device.poll(true, null);
@@ -169,6 +162,7 @@ pub fn main() !void {
         defer staging_buffer.unmap();
 
         const output = buf[0..output_size];
+        std.fs.cwd().makeDir("examples/output") catch {};
         try bmp.write24BitBMP("examples/output/triangle.bmp", output_extent.width, output_extent.height, output);
     }
 }

--- a/examples/triangle/triangle.zig
+++ b/examples/triangle/triangle.zig
@@ -162,7 +162,7 @@ pub fn main() !void {
         defer staging_buffer.unmap();
 
         const output = buf[0..output_size];
-        std.fs.cwd().makeDir("examples/output") catch {};
+        try std.fs.cwd().makePath("examples/output");
         try bmp.write24BitBMP("examples/output/triangle.bmp", output_extent.width, output_extent.height, output);
     }
 }


### PR DESCRIPTION
- hi there! thanks for the project
- i am using a macbook pro m1
- here are some fixes in the build to get the static build running for triangle test
-  + when building statically link the Frameworks to the module
-  + create the output folder if its deleted

Q: do you know if Framework "QuartzCore" is really required? triangle test works without it

note: depending on system installed macos frameworks makes the build non portable aka you can not cross compile from another platform. 