### PR TITLE
Update to Zig 0.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ b.getInstallStep().dependOn(&install_dll.step);
         message: StringView,
         userdata1: ?*anyopaque,
         userdata2: ?*anyopaque
-    ) callconv(.C) void {
+    ) callconv(.c) void {
         switch(status) {
             .success => {
                 const ud_adapter: **Adapter = @ptrCast(@alignCast(userdata1));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,7 +8,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.2",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/examples/bmp.zig
+++ b/examples/bmp.zig
@@ -4,7 +4,8 @@ pub fn write24BitBMP(file_name: []const u8, comptime width: u32, comptime height
     const file = try std.fs.cwd().createFile(file_name, .{});
     defer file.close();
 
-    var writer = file.writer();
+    // TODO: Use the new writer
+    var writer = file.deprecatedWriter();
 
     // ID
     _ = try writer.write(&[2]u8{'B', 'M'});

--- a/examples/triangle/triangle.zig
+++ b/examples/triangle/triangle.zig
@@ -10,7 +10,7 @@ const output_extent = wgpu.Extent3D {
 const output_bytes_per_row = 4 * output_extent.width;
 const output_size = output_bytes_per_row * output_extent.height;
 
-fn handleBufferMap(status: wgpu.MapAsyncStatus, _: wgpu.StringView, userdata1: ?*anyopaque, _: ?*anyopaque) callconv(.C) void {
+fn handleBufferMap(status: wgpu.MapAsyncStatus, _: wgpu.StringView, userdata1: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     std.log.info("buffer_map status={x:.8}\n", .{@intFromEnum(status)});
     const complete: *bool = @ptrCast(@alignCast(userdata1));
     complete.* = true;

--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -167,7 +167,7 @@ pub const RequestAdapterCallbackInfo = extern struct {
             @compileError("userdata should be a pointer type");
         }
         const Trampoline = struct {
-            fn cb(status: RequestAdapterStatus, adapter: ?*Adapter, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+            fn cb(status: RequestAdapterStatus, adapter: ?*Adapter, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
                 const wrapped_callback: CallbackType = @ptrCast(userdata2);
                 const _userdata: UserDataType = @ptrCast(@alignCast(userdata1));
                 const response: RequestAdapterError!*Adapter = switch (status) {
@@ -199,7 +199,7 @@ pub const RequestAdapterCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 
 extern fn wgpuAdapterInfoFreeMembers(adapter_info: WGPUAdapterInfo) void;

--- a/src/buffer.zig
+++ b/src/buffer.zig
@@ -77,7 +77,7 @@ pub const BufferMapCallbackInfo = extern struct {
     userdata2: ?*anyopaque = null,
 };
 
-pub const BufferMapCallback = *const fn(status: MapAsyncStatus, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const BufferMapCallback = *const fn(status: MapAsyncStatus, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 pub const BufferDescriptor = extern struct {
     next_in_chain: ?*const ChainedStruct = null,

--- a/src/device.zig
+++ b/src/device.zig
@@ -78,8 +78,8 @@ pub const DeviceLostReason = enum(u32) {
 };
 
 // `device` is a reference to the device which was lost. If, and only if, the `reason` is DeviceLostReason.failed_creation, `device` is a non-null pointer to a null Device.
-pub const DeviceLostCallback = *const fn(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
-pub fn defaultDeviceLostCallback(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+pub const DeviceLostCallback = *const fn(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
+pub fn defaultDeviceLostCallback(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
     _ = device;
     _ = userdata1;
     _ = userdata2;
@@ -114,7 +114,7 @@ pub const DeviceLostCallbackInfo = extern struct {
             @compileError("userdata should be a pointer type");
         }
         const Trampoline = struct {
-            fn cb(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+            fn cb(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
                 const wrapped_callback: CallbackType = @ptrCast(userdata2);
                 const _userdata: UserDataType = @ptrCast(@alignCast(userdata1));
                 wrapped_callback(device, reason, message.toSlice(), _userdata);
@@ -166,8 +166,8 @@ pub const ErrorType = enum(u32) {
     unknown       = 0x00000005,
 };
 
-pub const UncapturedErrorCallback = *const fn(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
-pub fn defaultUncapturedErrorCallback(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+pub const UncapturedErrorCallback = *const fn(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
+pub fn defaultUncapturedErrorCallback(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
     _ = device;
     _ = userdata1;
     _ = userdata2;
@@ -197,7 +197,7 @@ pub const UncapturedErrorCallbackInfo = extern struct {
             @compileError("userdata should be a pointer type");
         }
         const Trampoline = struct {
-            fn cb(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+            fn cb(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
                 const wrapped_callback: CallbackType = @ptrCast(userdata2);
                 const _userdata: UserDataType = @ptrCast(@alignCast(userdata1));
                 wrapped_callback(device, error_type, message.toSlice(), _userdata);
@@ -315,7 +315,7 @@ pub const RequestDeviceCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const RequestDeviceCallbackInfo = extern struct {
     next_in_chain: ?*ChainedStruct = null,
@@ -338,7 +338,7 @@ pub const RequestDeviceCallbackInfo = extern struct {
             @compileError("userdata should be a pointer type");
         }
         const Trampoline = struct {
-            fn cb(status: RequestDeviceStatus, device: ?*Device, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+            fn cb(status: RequestDeviceStatus, device: ?*Device, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
                 const wrapped_callback: CallbackType = @ptrCast(userdata2);
                 const _userdata: UserDataType = @ptrCast(@alignCast(userdata1));
                 const response: RequestDeviceError!*Device = switch (status) {
@@ -386,7 +386,7 @@ pub const PopErrorScopeCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const PopErrorScopeCallbackInfo = extern struct {
     next_in_chain: ?*ChainedStruct = null,

--- a/src/log.zig
+++ b/src/log.zig
@@ -9,7 +9,7 @@ pub const LogLevel = enum(u32) {
     trace    = 0x00000005,
 };
 
-pub const LogCallback = *const fn(level: LogLevel, message: StringView, userdata: ?*anyopaque) callconv(.C) void;
+pub const LogCallback = *const fn(level: LogLevel, message: StringView, userdata: ?*anyopaque) callconv(.c) void;
 
 extern fn wgpuSetLogCallback(callback: LogCallback, userdata: ?*anyopaque) void;
 extern fn wgpuSetLogLevel(level: LogLevel) void;

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -122,7 +122,7 @@ pub const CreateComputePipelineAsyncCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 extern fn wgpuComputePipelineGetBindGroupLayout(compute_pipeline: *ComputePipeline, group_index: u32) ?*BindGroupLayout;
 extern fn wgpuComputePipelineSetLabel(compute_pipeline: *ComputePipeline, label: StringView) void;
@@ -453,4 +453,4 @@ pub const CreateRenderPipelineAsyncCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -38,7 +38,7 @@ pub const QueueWorkDoneCallbackInfo = extern struct {
     userdata2: ?*anyopaque = null,
 };
 
-pub const QueueWorkDoneCallback = *const fn(status: WorkDoneStatus, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const QueueWorkDoneCallback = *const fn(status: WorkDoneStatus, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 extern fn wgpuQueueOnSubmittedWorkDone(queue: *Queue, callback_info: QueueWorkDoneCallbackInfo) Future;
 extern fn wgpuQueueSetLabel(queue: *Queue, label: StringView) void;

--- a/src/shader.zig
+++ b/src/shader.zig
@@ -151,7 +151,7 @@ pub const CompilationInfo = extern struct {
     messages: [*]const CompilationMessage,
 };
 
-pub const CompilationInfoCallback = *const fn(status: CompilationInfoRequestStatus, compilationInfo: ?*const CompilationInfo, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const CompilationInfoCallback = *const fn(status: CompilationInfoRequestStatus, compilationInfo: ?*const CompilationInfo, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 pub const CompilationInfoCallbackInfo = extern struct {
     next_in_chain: ?*const ChainedStruct = null,

--- a/tests/compute.zig
+++ b/tests/compute.zig
@@ -3,7 +3,7 @@ const testing = std.testing;
 
 const wgpu = @import("wgpu");
 
-fn handleBufferMap(status: wgpu.MapAsyncStatus, _: wgpu.StringView, userdata1: ?*anyopaque, _: ?*anyopaque) callconv(.C) void {
+fn handleBufferMap(status: wgpu.MapAsyncStatus, _: wgpu.StringView, userdata1: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     std.log.info("buffer_map status={x:.8}\n", .{@intFromEnum(status)});
     const completed: *bool = @ptrCast(@alignCast(userdata1));
     completed.* = true;

--- a/tests/compute_c.zig
+++ b/tests/compute_c.zig
@@ -3,7 +3,7 @@ const testing = std.testing;
 
 const wgpu = @import("wgpu-c");
 
-fn handleRequestAdapter(status: wgpu.WGPURequestAdapterStatus, adapter: wgpu.WGPUAdapter, _: wgpu.WGPUStringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+fn handleRequestAdapter(status: wgpu.WGPURequestAdapterStatus, adapter: wgpu.WGPUAdapter, _: wgpu.WGPUStringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
     switch(status) {
         wgpu.WGPURequestAdapterStatus_Success => {
             const ud_adapter: *wgpu.WGPUAdapter = @ptrCast(@alignCast(userdata1));
@@ -17,7 +17,7 @@ fn handleRequestAdapter(status: wgpu.WGPURequestAdapterStatus, adapter: wgpu.WGP
     completed.* = true;
 }
 
-fn handleRequestDevice(status: wgpu.WGPURequestDeviceStatus, device: wgpu.WGPUDevice, _: wgpu.WGPUStringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+fn handleRequestDevice(status: wgpu.WGPURequestDeviceStatus, device: wgpu.WGPUDevice, _: wgpu.WGPUStringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
     switch(status) {
         wgpu.WGPURequestDeviceStatus_Success => {
             const ud_device: *wgpu.WGPUDevice = @ptrCast(@alignCast(userdata1));
@@ -31,7 +31,7 @@ fn handleRequestDevice(status: wgpu.WGPURequestDeviceStatus, device: wgpu.WGPUDe
     completed.* = true;
 }
 
-fn handleBufferMap(status: wgpu.WGPUMapAsyncStatus, _: wgpu.WGPUStringView, userdata1: ?*anyopaque, _: ?*anyopaque) callconv(.C) void {
+fn handleBufferMap(status: wgpu.WGPUMapAsyncStatus, _: wgpu.WGPUStringView, userdata1: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     std.log.info("buffer_map status={x:.8}\n", .{status});
     const completed: *bool = @ptrCast(@alignCast(userdata1));
     completed.* = true;


### PR DESCRIPTION
For the convenience of being able to use WebGPU in Zig 0.15.2, on the idiomatic branch. 

To note:
- I only used the currently existing examples to see what breaks and needs changing. If something else is broken, that wasn't covered by those
- The triangle example uses the now deprecated writer, so I added a todo to later use the new writer
