### PR TITLE
Fix Zig 0.15 compatibility: Replace .C with .c calling convention

### DIFF
--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -110,7 +110,7 @@ pub const RequestAdapterCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const RequestAdapterResponse = struct {
     status: RequestAdapterStatus,
@@ -119,7 +119,7 @@ pub const RequestAdapterResponse = struct {
 };
 
 pub const AdapterInfoProcs = struct {
-    pub const FreeMembers = *const fn(AdapterInfo) callconv(.C) void;
+    pub const FreeMembers = *const fn(AdapterInfo) callconv(.c) void;
 };
 
 extern fn wgpuAdapterInfoFreeMembers(adapter_info: AdapterInfo) void;
@@ -141,13 +141,13 @@ pub const AdapterInfo = extern struct {
 };
 
 pub const AdapterProcs = struct {
-    pub const GetFeatures = *const fn(*Adapter, *SupportedFeatures) callconv(.C) void;
-    pub const GetLimits = *const fn(*Adapter, *Limits) callconv(.C) Status;
-    pub const GetInfo = *const fn(*Adapter, *AdapterInfo) callconv(.C) Status;
-    pub const HasFeature = *const fn(*Adapter, FeatureName) callconv(.C) WGPUBool;
-    pub const RequestDevice = *const fn(*Adapter, ?*const DeviceDescriptor, RequestDeviceCallbackInfo) callconv(.C) Future;
-    pub const AddRef = *const fn(*Adapter) callconv(.C) void;
-    pub const Release = *const fn(*Adapter) callconv(.C) void;
+    pub const GetFeatures = *const fn(*Adapter, *SupportedFeatures) callconv(.c) void;
+    pub const GetLimits = *const fn(*Adapter, *Limits) callconv(.c) Status;
+    pub const GetInfo = *const fn(*Adapter, *AdapterInfo) callconv(.c) Status;
+    pub const HasFeature = *const fn(*Adapter, FeatureName) callconv(.c) WGPUBool;
+    pub const RequestDevice = *const fn(*Adapter, ?*const DeviceDescriptor, RequestDeviceCallbackInfo) callconv(.c) Future;
+    pub const AddRef = *const fn(*Adapter) callconv(.c) void;
+    pub const Release = *const fn(*Adapter) callconv(.c) void;
 };
 
 extern fn wgpuAdapterGetFeatures(adapter: *Adapter, features: *SupportedFeatures) void;
@@ -172,7 +172,7 @@ pub const Adapter = opaque{
         return wgpuAdapterHasFeature(self, feature) != 0;
     }
 
-    fn defaultDeviceCallback(status: RequestDeviceStatus, device: ?*Device, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+    fn defaultDeviceCallback(status: RequestDeviceStatus, device: ?*Device, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
         const ud_response: *RequestDeviceResponse = @ptrCast(@alignCast(userdata1));
         ud_response.* = RequestDeviceResponse {
             .status = status,

--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -68,9 +68,9 @@ pub const BindGroupLayoutDescriptor = extern struct {
 };
 
 pub const BindGroupLayoutProcs = struct {
-    pub const SetLabel = *const fn(*BindGroupLayout, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*BindGroupLayout) callconv(.C) void;
-    pub const Release = *const fn(*BindGroupLayout) callconv(.C) void;
+    pub const SetLabel = *const fn(*BindGroupLayout, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*BindGroupLayout) callconv(.c) void;
+    pub const Release = *const fn(*BindGroupLayout) callconv(.c) void;
 };
 
 extern fn wgpuBindGroupLayoutSetLabel(bind_group_layout: *BindGroupLayout, label: StringView) void;
@@ -129,9 +129,9 @@ pub const BindGroupDescriptor = extern struct {
 };
 
 pub const BindGroupProcs = struct {
-    pub const SetLabel = *const fn(*BindGroup, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*BindGroup) callconv(.C) void;
-    pub const Release = *const fn(*BindGroup) callconv(.C) void;
+    pub const SetLabel = *const fn(*BindGroup, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*BindGroup) callconv(.c) void;
+    pub const Release = *const fn(*BindGroup) callconv(.c) void;
 };
 
 extern fn wgpuBindGroupSetLabel(bind_group: *BindGroup, label: StringView) void;

--- a/src/buffer.zig
+++ b/src/buffer.zig
@@ -75,7 +75,7 @@ pub const BufferMapCallbackInfo = extern struct {
     userdata2: ?*anyopaque = null,
 };
 
-pub const BufferMapCallback = *const fn(status: MapAsyncStatus, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const BufferMapCallback = *const fn(status: MapAsyncStatus, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 pub const BufferDescriptor = extern struct {
     next_in_chain: ?*const ChainedStruct = null,
@@ -86,17 +86,17 @@ pub const BufferDescriptor = extern struct {
 };
 
 pub const BufferProcs = struct {
-    pub const Destroy = *const fn(*Buffer) callconv(.C) void;
-    pub const GetConstMappedRange = *const fn(*Buffer, usize, usize) callconv(.C) ?*const anyopaque;
-    pub const GetMapState = *const fn(*Buffer) callconv(.C) BufferMapState;
-    pub const GetMappedRange = *const fn(*Buffer, usize, usize) callconv(.C) ?*anyopaque;
-    pub const GetSize = *const fn(*Buffer) callconv(.C) u64;
-    pub const GetUsage = *const fn(*Buffer) callconv(.C) BufferUsage;
-    pub const MapAsync = *const fn(*Buffer, MapMode, usize, usize, BufferMapCallbackInfo) callconv(.C) Future;
-    pub const SetLabel = *const fn(*Buffer, StringView) callconv(.C) void;
-    pub const Unmap = *const fn(*Buffer) callconv(.C) void;
-    pub const AddRef = *const fn(*Buffer) callconv(.C) void;
-    pub const Release = *const fn(*Buffer) callconv(.C) void;
+    pub const Destroy = *const fn(*Buffer) callconv(.c) void;
+    pub const GetConstMappedRange = *const fn(*Buffer, usize, usize) callconv(.c) ?*const anyopaque;
+    pub const GetMapState = *const fn(*Buffer) callconv(.c) BufferMapState;
+    pub const GetMappedRange = *const fn(*Buffer, usize, usize) callconv(.c) ?*anyopaque;
+    pub const GetSize = *const fn(*Buffer) callconv(.c) u64;
+    pub const GetUsage = *const fn(*Buffer) callconv(.c) BufferUsage;
+    pub const MapAsync = *const fn(*Buffer, MapMode, usize, usize, BufferMapCallbackInfo) callconv(.c) Future;
+    pub const SetLabel = *const fn(*Buffer, StringView) callconv(.c) void;
+    pub const Unmap = *const fn(*Buffer) callconv(.c) void;
+    pub const AddRef = *const fn(*Buffer) callconv(.c) void;
+    pub const Release = *const fn(*Buffer) callconv(.c) void;
 };
 
 extern fn wgpuBufferDestroy(buffer: *Buffer) void;

--- a/src/command_encoder.zig
+++ b/src/command_encoder.zig
@@ -50,23 +50,23 @@ pub const CommandEncoderDescriptor = extern struct {
 };
 
 const ComputePassEncoderProcs = struct {
-    pub const DispatchWorkgroups = *const fn(*ComputePassEncoder, u32, u32, u32) callconv(.C) void;
-    pub const DispatchWorkgroupsIndirect = *const fn(*ComputePassEncoder, *Buffer, u64) callconv(.C) void;
-    pub const End = *const fn(*ComputePassEncoder) callconv(.C) void;
-    pub const InsertDebugMarker = *const fn(*ComputePassEncoder, StringView) callconv(.C) void;
-    pub const PopDebugGroup = *const fn(*ComputePassEncoder) callconv(.C) void;
-    pub const PushDebugGroup = *const fn(*ComputePassEncoder, StringView) callconv(.C) void;
-    pub const SetBindGroup = *const fn(*ComputePassEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.C) void;
-    pub const SetLabel = *const fn(*ComputePassEncoder, StringView) callconv(.C) void;
-    pub const SetPipeline = *const fn(*ComputePassEncoder, *ComputePipeline) callconv(.C) void;
-    pub const AddRef = *const fn(*ComputePassEncoder) callconv(.C) void;
-    pub const Release = *const fn(*ComputePassEncoder) callconv(.C) void;
+    pub const DispatchWorkgroups = *const fn(*ComputePassEncoder, u32, u32, u32) callconv(.c) void;
+    pub const DispatchWorkgroupsIndirect = *const fn(*ComputePassEncoder, *Buffer, u64) callconv(.c) void;
+    pub const End = *const fn(*ComputePassEncoder) callconv(.c) void;
+    pub const InsertDebugMarker = *const fn(*ComputePassEncoder, StringView) callconv(.c) void;
+    pub const PopDebugGroup = *const fn(*ComputePassEncoder) callconv(.c) void;
+    pub const PushDebugGroup = *const fn(*ComputePassEncoder, StringView) callconv(.c) void;
+    pub const SetBindGroup = *const fn(*ComputePassEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.c) void;
+    pub const SetLabel = *const fn(*ComputePassEncoder, StringView) callconv(.c) void;
+    pub const SetPipeline = *const fn(*ComputePassEncoder, *ComputePipeline) callconv(.c) void;
+    pub const AddRef = *const fn(*ComputePassEncoder) callconv(.c) void;
+    pub const Release = *const fn(*ComputePassEncoder) callconv(.c) void;
 
     // wgpu-native procs?
-    // pub const SetPushConstants = *const fn(*ComputePassEncoder, u32, u32, *const anyopaque) callconv(.C) void;
-    // pub const BeginPipelineStatisticsQuery = *const fn(*ComputePassEncoder, *QuerySet, u32) callconv(.C) void;
-    // pub const EndPipelineStatisticsQuery = *const fn(*ComputePassEncoder) callconv(.C) void;
-    // pub const WriteTimestamp = *const fn(*ComputePassEncoder, *QuerySet, u32) callconv(.C) void;
+    // pub const SetPushConstants = *const fn(*ComputePassEncoder, u32, u32, *const anyopaque) callconv(.c) void;
+    // pub const BeginPipelineStatisticsQuery = *const fn(*ComputePassEncoder, *QuerySet, u32) callconv(.c) void;
+    // pub const EndPipelineStatisticsQuery = *const fn(*ComputePassEncoder) callconv(.c) void;
+    // pub const WriteTimestamp = *const fn(*ComputePassEncoder, *QuerySet, u32) callconv(.c) void;
 };
 
 extern fn wgpuComputePassEncoderDispatchWorkgroups(compute_pass_encoder: *ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) void;
@@ -211,38 +211,38 @@ pub const RenderPassDescriptor = extern struct {
 };
 
 pub const RenderPassEncoderProcs = struct {
-    pub const BeginOcclusionQuery = *const fn(*RenderPassEncoder, u32) callconv(.C) void;
-    pub const Draw = *const fn(*RenderPassEncoder, u32, u32, u32, u32) callconv(.C) void;
-    pub const DrawIndexed = *const fn(*RenderPassEncoder, u32, u32, u32, i32, u32) callconv(.C) void;
-    pub const DrawIndexedIndirect = *const fn(*RenderPassEncoder, *Buffer, u64) callconv(.C) void;
-    pub const DrawIndirect = *const fn(*RenderPassEncoder, *Buffer, u64) callconv(.C) void;
-    pub const End = *const fn(*RenderPassEncoder) callconv(.C) void;
-    pub const EndOcclusionQuery = *const fn(*RenderPassEncoder) callconv(.C) void;
-    pub const ExecuteBundles = *const fn(*RenderPassEncoder, usize, [*]const *const RenderBundle) callconv(.C) void;
-    pub const InsertDebugMarker = *const fn(*RenderPassEncoder, StringView) callconv(.C) void;
-    pub const PopDebugGroup = *const fn(*RenderPassEncoder) callconv(.C) void;
-    pub const PushDebugGroup = *const fn(*RenderPassEncoder, StringView) callconv(.C) void;
-    pub const SetBindGroup = *const fn(*RenderPassEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.C) void;
-    pub const SetBlendConstant = *const fn(*RenderPassEncoder, *const Color) callconv(.C) void;
-    pub const SetIndexBuffer = *const fn(*RenderPassEncoder, *Buffer, IndexFormat, u64, u64) callconv(.C) void;
-    pub const SetLabel = *const fn(*RenderPassEncoder, StringView) callconv(.C) void;
-    pub const SetPipeline = *const fn(*RenderPassEncoder, *RenderPipeline) callconv(.C) void;
-    pub const SetScissorRect = *const fn(*RenderPassEncoder, u32, u32, u32, u32) callconv(.C) void;
-    pub const SetStencilReference = *const fn(*RenderPassEncoder, u32) callconv(.C) void;
-    pub const SetVertexBuffer = *const fn(*RenderPassEncoder, u32, *Buffer, u64, u64) callconv(.C) void;
-    pub const SetViewport = *const fn(*RenderPassEncoder, f32, f32, f32, f32, f32, f32) callconv(.C) void;
-    pub const AddRef = *const fn(*RenderPassEncoder) callconv(.C) void;
-    pub const Release = *const fn(*RenderPassEncoder) callconv(.C) void;
+    pub const BeginOcclusionQuery = *const fn(*RenderPassEncoder, u32) callconv(.c) void;
+    pub const Draw = *const fn(*RenderPassEncoder, u32, u32, u32, u32) callconv(.c) void;
+    pub const DrawIndexed = *const fn(*RenderPassEncoder, u32, u32, u32, i32, u32) callconv(.c) void;
+    pub const DrawIndexedIndirect = *const fn(*RenderPassEncoder, *Buffer, u64) callconv(.c) void;
+    pub const DrawIndirect = *const fn(*RenderPassEncoder, *Buffer, u64) callconv(.c) void;
+    pub const End = *const fn(*RenderPassEncoder) callconv(.c) void;
+    pub const EndOcclusionQuery = *const fn(*RenderPassEncoder) callconv(.c) void;
+    pub const ExecuteBundles = *const fn(*RenderPassEncoder, usize, [*]const *const RenderBundle) callconv(.c) void;
+    pub const InsertDebugMarker = *const fn(*RenderPassEncoder, StringView) callconv(.c) void;
+    pub const PopDebugGroup = *const fn(*RenderPassEncoder) callconv(.c) void;
+    pub const PushDebugGroup = *const fn(*RenderPassEncoder, StringView) callconv(.c) void;
+    pub const SetBindGroup = *const fn(*RenderPassEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.c) void;
+    pub const SetBlendConstant = *const fn(*RenderPassEncoder, *const Color) callconv(.c) void;
+    pub const SetIndexBuffer = *const fn(*RenderPassEncoder, *Buffer, IndexFormat, u64, u64) callconv(.c) void;
+    pub const SetLabel = *const fn(*RenderPassEncoder, StringView) callconv(.c) void;
+    pub const SetPipeline = *const fn(*RenderPassEncoder, *RenderPipeline) callconv(.c) void;
+    pub const SetScissorRect = *const fn(*RenderPassEncoder, u32, u32, u32, u32) callconv(.c) void;
+    pub const SetStencilReference = *const fn(*RenderPassEncoder, u32) callconv(.c) void;
+    pub const SetVertexBuffer = *const fn(*RenderPassEncoder, u32, *Buffer, u64, u64) callconv(.c) void;
+    pub const SetViewport = *const fn(*RenderPassEncoder, f32, f32, f32, f32, f32, f32) callconv(.c) void;
+    pub const AddRef = *const fn(*RenderPassEncoder) callconv(.c) void;
+    pub const Release = *const fn(*RenderPassEncoder) callconv(.c) void;
 
     // wgpu-native procs?
-    // pub const SetPushConstants = *const fn(*RenderPassEncoder, ShaderStage, u32, u32, *const anyopaque) callconv(.C) void;
-    // pub const MultiDrawIndirect = *const fn(*RenderPassEncoder, *Buffer, u64, u32) callconv(.C) void;
-    // pub const MultiDrawIndexedIndirect = *const fn(*RenderPassEncoder, *Buffer, u64, u32) callconv(.C) void;
-    // pub const MultiDrawIndirectCount = *const fn(*RenderPassEncoder, *Buffer, u64, *Buffer, u64, u32) callconv(.C) void;
-    // pub const MultiDrawIndexedIndirectCount = *const fn(*RenderPassEncoder, *Buffer, u64, *Buffer, u64, u32) callconv(.C) void;
-    // pub const BeginPipelineStatisticsQuery = *const fn(*RenderPassEncoder, *QuerySet, u32) callconv(.C) void;
-    // pub const EndPipelineStatisticsQuery = *const fn(*RenderPassEncoder) callconv(.C) void;
-    // pub const WriteTimestamp = *const fn(*RenderPassEncoder, *QuerySet, u32) callconv(.C) void;
+    // pub const SetPushConstants = *const fn(*RenderPassEncoder, ShaderStage, u32, u32, *const anyopaque) callconv(.c) void;
+    // pub const MultiDrawIndirect = *const fn(*RenderPassEncoder, *Buffer, u64, u32) callconv(.c) void;
+    // pub const MultiDrawIndexedIndirect = *const fn(*RenderPassEncoder, *Buffer, u64, u32) callconv(.c) void;
+    // pub const MultiDrawIndirectCount = *const fn(*RenderPassEncoder, *Buffer, u64, *Buffer, u64, u32) callconv(.c) void;
+    // pub const MultiDrawIndexedIndirectCount = *const fn(*RenderPassEncoder, *Buffer, u64, *Buffer, u64, u32) callconv(.c) void;
+    // pub const BeginPipelineStatisticsQuery = *const fn(*RenderPassEncoder, *QuerySet, u32) callconv(.c) void;
+    // pub const EndPipelineStatisticsQuery = *const fn(*RenderPassEncoder) callconv(.c) void;
+    // pub const WriteTimestamp = *const fn(*RenderPassEncoder, *QuerySet, u32) callconv(.c) void;
 };
 
 extern fn wgpuRenderPassEncoderBeginOcclusionQuery(render_pass_encoder: *RenderPassEncoder, query_index: u32) void;
@@ -383,9 +383,9 @@ pub const CommandBufferDescriptor = extern struct {
 };
 
 pub const CommandBufferProcs = struct {
-    pub const SetLabel = *const fn(*CommandBuffer, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*CommandBuffer) callconv(.C) void;
-    pub const Release = *const fn(*CommandBuffer) callconv(.C) void;
+    pub const SetLabel = *const fn(*CommandBuffer, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*CommandBuffer) callconv(.c) void;
+    pub const Release = *const fn(*CommandBuffer) callconv(.c) void;
 };
 
 extern fn wgpuCommandBufferSetLabel(command_buffer: *CommandBuffer, label: StringView) void;
@@ -408,22 +408,22 @@ pub const CommandBuffer = opaque {
 };
 
 pub const CommandEncoderProcs = struct {
-    pub const BeginComputePass = *const fn(*CommandEncoder, ?*const ComputePassDescriptor) callconv(.C) ?*ComputePassEncoder;
-    pub const BeginRenderPass = *const fn(*CommandEncoder, *const RenderPassDescriptor) callconv(.C) ?*RenderPassEncoder;
-    pub const ClearBuffer = *const fn(*CommandEncoder, *Buffer, u64, u64) callconv(.C) void;
-    pub const CopyBufferToBuffer = *const fn(*CommandEncoder, *Buffer, u64, *Buffer, u64, u64) callconv(.C) void;
-    pub const CopyBufferToTexture = *const fn(*CommandEncoder, *const TexelCopyBufferInfo, *const TexelCopyTextureInfo, *const Extent3D) callconv(.C) void;
-    pub const CopyTextureToBuffer = *const fn(*CommandEncoder, *const TexelCopyTextureInfo, *const TexelCopyBufferInfo, *const Extent3D) callconv(.C) void;
-    pub const CopyTextureToTexture = *const fn(*CommandEncoder, *const TexelCopyTextureInfo, *const TexelCopyTextureInfo, *const Extent3D) callconv(.C) void;
-    pub const Finish = *const fn(*CommandEncoder, ?*const CommandBufferDescriptor) callconv(.C) ?*CommandBuffer;
-    pub const InsertDebugMarker = *const fn(*CommandEncoder, StringView) callconv(.C) void;
-    pub const PopDebugGroup = *const fn(*CommandEncoder) callconv(.C) void;
-    pub const PushDebugGroup = *const fn(*CommandEncoder, StringView) callconv(.C) void;
-    pub const ResolveQuerySet = *const fn(*CommandEncoder, *QuerySet, u32, u32, *Buffer, u64) callconv(.C) void;
-    pub const SetLabel = *const fn(*CommandEncoder, StringView) callconv(.C) void;
-    pub const WriteTimestamp = *const fn(*CommandEncoder, *QuerySet, u32) callconv(.C) void;
-    pub const AddRef = *const fn(*CommandEncoder) callconv(.C) void;
-    pub const Release = *const fn(*CommandEncoder) callconv(.C) void;
+    pub const BeginComputePass = *const fn(*CommandEncoder, ?*const ComputePassDescriptor) callconv(.c) ?*ComputePassEncoder;
+    pub const BeginRenderPass = *const fn(*CommandEncoder, *const RenderPassDescriptor) callconv(.c) ?*RenderPassEncoder;
+    pub const ClearBuffer = *const fn(*CommandEncoder, *Buffer, u64, u64) callconv(.c) void;
+    pub const CopyBufferToBuffer = *const fn(*CommandEncoder, *Buffer, u64, *Buffer, u64, u64) callconv(.c) void;
+    pub const CopyBufferToTexture = *const fn(*CommandEncoder, *const TexelCopyBufferInfo, *const TexelCopyTextureInfo, *const Extent3D) callconv(.c) void;
+    pub const CopyTextureToBuffer = *const fn(*CommandEncoder, *const TexelCopyTextureInfo, *const TexelCopyBufferInfo, *const Extent3D) callconv(.c) void;
+    pub const CopyTextureToTexture = *const fn(*CommandEncoder, *const TexelCopyTextureInfo, *const TexelCopyTextureInfo, *const Extent3D) callconv(.c) void;
+    pub const Finish = *const fn(*CommandEncoder, ?*const CommandBufferDescriptor) callconv(.c) ?*CommandBuffer;
+    pub const InsertDebugMarker = *const fn(*CommandEncoder, StringView) callconv(.c) void;
+    pub const PopDebugGroup = *const fn(*CommandEncoder) callconv(.c) void;
+    pub const PushDebugGroup = *const fn(*CommandEncoder, StringView) callconv(.c) void;
+    pub const ResolveQuerySet = *const fn(*CommandEncoder, *QuerySet, u32, u32, *Buffer, u64) callconv(.c) void;
+    pub const SetLabel = *const fn(*CommandEncoder, StringView) callconv(.c) void;
+    pub const WriteTimestamp = *const fn(*CommandEncoder, *QuerySet, u32) callconv(.c) void;
+    pub const AddRef = *const fn(*CommandEncoder) callconv(.c) void;
+    pub const Release = *const fn(*CommandEncoder) callconv(.c) void;
 };
 
 extern fn wgpuCommandEncoderBeginComputePass(command_encoder: *CommandEncoder, descriptor: ?*const ComputePassDescriptor) ?*ComputePassEncoder;

--- a/src/device.zig
+++ b/src/device.zig
@@ -92,8 +92,8 @@ pub const DeviceLostCallbackInfo = extern struct {
 };
 
 // `device` is a reference to the device which was lost. If, and only if, the `reason` is DeviceLostReason.failed_creation, `device` is a non-null pointer to a null Device.
-pub const DeviceLostCallback = *const fn(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
-pub fn defaultDeviceLostCallback(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+pub const DeviceLostCallback = *const fn(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
+pub fn defaultDeviceLostCallback(device: *const ?*Device, reason: DeviceLostReason, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
     _ = device;
     _ = userdata1;
     _ = userdata2;
@@ -120,7 +120,7 @@ pub const ErrorType = enum(u32) {
     unknown       = 0x00000005,
 };
 
-pub const UncapturedErrorCallback = *const fn(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const UncapturedErrorCallback = *const fn(device: ?*Device, error_type: ErrorType, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 pub const ErrorFilter = enum(u32) {
     validation    = 0x00000001,
@@ -168,7 +168,7 @@ pub const RequestDeviceCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const RequestDeviceResponse = struct {
     status: RequestDeviceStatus,
@@ -210,7 +210,7 @@ pub const PopErrorScopeCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const PopErrorScopeCallbackInfo = extern struct {
     next_in_chain: ?*ChainedStruct = null,
@@ -224,36 +224,36 @@ pub const PopErrorScopeCallbackInfo = extern struct {
 };
 
 pub const DeviceProcs = struct {
-    pub const CreateBindGroup = *const fn(*Device, *const BindGroupDescriptor) callconv(.C) ?*BindGroup;
-    pub const CreateBindGroupLayout = *const fn(*Device, *const BindGroupLayoutDescriptor) callconv(.C) ?*BindGroupLayout;
-    pub const CreateBuffer = *const fn(*Device, *const BufferDescriptor) callconv(.C) ?*Buffer;
-    pub const CreateCommandEncoder = *const fn(*Device, *const CommandEncoderDescriptor) callconv(.C) ?*CommandEncoder;
-    pub const CreateComputePipeline = *const fn(*Device, *const ComputePipelineDescriptor) callconv(.C) ?*ComputePipeline;
-    pub const CreateComputePipelineAsync = *const fn(*Device, *const ComputePipelineDescriptor, CreateComputePipelineAsyncCallbackInfo) callconv(.C) Future;
-    pub const CreatePipelineLayout = *const fn(*Device, *const PipelineLayoutDescriptor) callconv(.C) ?*PipelineLayout;
-    pub const CreateQuerySet = *const fn(*Device, *const QuerySetDescriptor) callconv(.C) ?*QuerySet;
-    pub const CreateRenderBundleEncoder = *const fn(*Device, *const RenderBundleEncoderDescriptor) callconv(.C) ?*RenderBundleEncoder;
-    pub const CreateRenderPipeline = *const fn(*Device, *const RenderPipelineDescriptor) callconv(.C) ?*RenderPipeline;
-    pub const CreateRenderPipelineAsync = *const fn(*Device, *const RenderPipelineDescriptor, CreateRenderPipelineAsyncCallbackInfo) callconv(.C) Future;
-    pub const CreateSampler = *const fn(*Device, *const SamplerDescriptor) callconv(.C) ?*Sampler;
-    pub const CreateShaderModule = *const fn(*Device, *const ShaderModuleDescriptor) callconv(.C) ?*ShaderModule;
-    pub const CreateTexture = *const fn(*Device, *const TextureDescriptor) callconv(.C) ?*Texture;
-    pub const Destroy = *const fn(*Device) callconv(.C) void;
-    pub const GetAdapterInfo = *const fn(*Device) callconv(.C) AdapterInfo;
-    pub const GetFeatures = *const fn(*Device, *SupportedFeatures) callconv(.C) void;
-    pub const GetLimits = *const fn(*Device, *Limits) callconv(.C) Status;
-    pub const GetLostFuture = *const fn(*Device) callconv(.C) Future;
-    pub const GetQueue = *const fn(*Device) callconv(.C) ?*Queue;
-    pub const HasFeature = *const fn(*Device, FeatureName) callconv(.C) WGPUBool;
-    pub const PopErrorScope = *const fn(*Device, PopErrorScopeCallbackInfo) callconv(.C) Future;
-    pub const PushErrorScope = *const fn(*Device, ErrorFilter) callconv(.C) void;
-    pub const SetLabel = *const fn(*Device, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*Device) callconv(.C) void;
-    pub const Release = *const fn(*Device) callconv(.C) void;
+    pub const CreateBindGroup = *const fn(*Device, *const BindGroupDescriptor) callconv(.c) ?*BindGroup;
+    pub const CreateBindGroupLayout = *const fn(*Device, *const BindGroupLayoutDescriptor) callconv(.c) ?*BindGroupLayout;
+    pub const CreateBuffer = *const fn(*Device, *const BufferDescriptor) callconv(.c) ?*Buffer;
+    pub const CreateCommandEncoder = *const fn(*Device, *const CommandEncoderDescriptor) callconv(.c) ?*CommandEncoder;
+    pub const CreateComputePipeline = *const fn(*Device, *const ComputePipelineDescriptor) callconv(.c) ?*ComputePipeline;
+    pub const CreateComputePipelineAsync = *const fn(*Device, *const ComputePipelineDescriptor, CreateComputePipelineAsyncCallbackInfo) callconv(.c) Future;
+    pub const CreatePipelineLayout = *const fn(*Device, *const PipelineLayoutDescriptor) callconv(.c) ?*PipelineLayout;
+    pub const CreateQuerySet = *const fn(*Device, *const QuerySetDescriptor) callconv(.c) ?*QuerySet;
+    pub const CreateRenderBundleEncoder = *const fn(*Device, *const RenderBundleEncoderDescriptor) callconv(.c) ?*RenderBundleEncoder;
+    pub const CreateRenderPipeline = *const fn(*Device, *const RenderPipelineDescriptor) callconv(.c) ?*RenderPipeline;
+    pub const CreateRenderPipelineAsync = *const fn(*Device, *const RenderPipelineDescriptor, CreateRenderPipelineAsyncCallbackInfo) callconv(.c) Future;
+    pub const CreateSampler = *const fn(*Device, *const SamplerDescriptor) callconv(.c) ?*Sampler;
+    pub const CreateShaderModule = *const fn(*Device, *const ShaderModuleDescriptor) callconv(.c) ?*ShaderModule;
+    pub const CreateTexture = *const fn(*Device, *const TextureDescriptor) callconv(.c) ?*Texture;
+    pub const Destroy = *const fn(*Device) callconv(.c) void;
+    pub const GetAdapterInfo = *const fn(*Device) callconv(.c) AdapterInfo;
+    pub const GetFeatures = *const fn(*Device, *SupportedFeatures) callconv(.c) void;
+    pub const GetLimits = *const fn(*Device, *Limits) callconv(.c) Status;
+    pub const GetLostFuture = *const fn(*Device) callconv(.c) Future;
+    pub const GetQueue = *const fn(*Device) callconv(.c) ?*Queue;
+    pub const HasFeature = *const fn(*Device, FeatureName) callconv(.c) WGPUBool;
+    pub const PopErrorScope = *const fn(*Device, PopErrorScopeCallbackInfo) callconv(.c) Future;
+    pub const PushErrorScope = *const fn(*Device, ErrorFilter) callconv(.c) void;
+    pub const SetLabel = *const fn(*Device, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*Device) callconv(.c) void;
+    pub const Release = *const fn(*Device) callconv(.c) void;
 
     // wgpu-native procs?
-    // pub const Poll = *const fn(*Device, WGPUBool, ?*const SubmissionIndex) callconv(.C) WGPUBool;
-    // pub const CreateShaderModuleSpirV = *const fn(*Device, *const ShaderModuleDescriptorSpirV) callconv(.C) ?*ShaderModule;
+    // pub const Poll = *const fn(*Device, WGPUBool, ?*const SubmissionIndex) callconv(.c) WGPUBool;
+    // pub const CreateShaderModuleSpirV = *const fn(*Device, *const ShaderModuleDescriptorSpirV) callconv(.c) ?*ShaderModule;
 };
 
 extern fn wgpuDeviceCreateBindGroup(device: *Device, descriptor: *const BindGroupDescriptor) ?*BindGroup;

--- a/src/global.zig
+++ b/src/global.zig
@@ -1,7 +1,7 @@
 // const StringView = @import("misc.zig").StringView;
 
 // Generic function return type for wgpuGetProcAddress
-// pub const Proc = *const fn() callconv(.C) void;
+// pub const Proc = *const fn() callconv(.c) void;
 
 // Supposedly getProcAddress is a global function, but it doesn't seem like it should work without being tied to a Device?
 // Could be it's one of those functions that's meant to be called with null the first time, TODO: look into that.

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -125,7 +125,7 @@ pub const WGSLLanguageFeatureName = enum(u32) {
 };
 
 pub const SupportedWGSLLanguageFeaturesProcs = struct {
-    pub const FreeMembers = *const fn(SupportedWGSLLanguageFeatures) callconv(.C) void;
+    pub const FreeMembers = *const fn(SupportedWGSLLanguageFeatures) callconv(.c) void;
 };
 
 extern fn wgpuSupportedWGSLLanguageFeaturesFreeMembers(supported_wgsl_language_features: SupportedWGSLLanguageFeatures) void;
@@ -142,21 +142,21 @@ pub const SupportedWGSLLanguageFeatures = extern struct {
 };
 
 pub const InstanceProcs = struct {
-    pub const CreateInstance = *const fn(?*const InstanceDescriptor) callconv(.C) ?*Instance;
-    pub const GetCapabilities = *const fn(*InstanceCapabilities) callconv(.C) Status;
+    pub const CreateInstance = *const fn(?*const InstanceDescriptor) callconv(.c) ?*Instance;
+    pub const GetCapabilities = *const fn(*InstanceCapabilities) callconv(.c) Status;
 
-    pub const CreateSurface = *const fn(*Instance, *const SurfaceDescriptor) callconv(.C) ?*Surface;
-    pub const GetWGSLLanguageFeatures = *const fn(*Instance, *SupportedWGSLLanguageFeatures) callconv(.C) Status;
-    pub const HasWGSLLanguageFeature = *const fn(*Instance, WGSLLanguageFeatureName) callconv(.C) WGPUBool;
-    pub const ProcessEvents = *const fn(*Instance) callconv(.C) void;
-    pub const RequestAdapter = *const fn(*Instance, ?*const RequestAdapterOptions, RequestAdapterCallbackInfo) callconv(.C) Future;
-    pub const WaitAny = *const fn(*Instance, usize, ?[*] FutureWaitInfo, u64) callconv(.C) WaitStatus;
-    pub const InstanceAddRef = *const fn(*Instance) callconv(.C) void;
-    pub const InstanceRelease = *const fn(*Instance) callconv(.C) void;
+    pub const CreateSurface = *const fn(*Instance, *const SurfaceDescriptor) callconv(.c) ?*Surface;
+    pub const GetWGSLLanguageFeatures = *const fn(*Instance, *SupportedWGSLLanguageFeatures) callconv(.c) Status;
+    pub const HasWGSLLanguageFeature = *const fn(*Instance, WGSLLanguageFeatureName) callconv(.c) WGPUBool;
+    pub const ProcessEvents = *const fn(*Instance) callconv(.c) void;
+    pub const RequestAdapter = *const fn(*Instance, ?*const RequestAdapterOptions, RequestAdapterCallbackInfo) callconv(.c) Future;
+    pub const WaitAny = *const fn(*Instance, usize, ?[*] FutureWaitInfo, u64) callconv(.c) WaitStatus;
+    pub const InstanceAddRef = *const fn(*Instance) callconv(.c) void;
+    pub const InstanceRelease = *const fn(*Instance) callconv(.c) void;
 
     // wgpu-native procs?
-    // pub const GenerateReport = *const fn(*Instance, *GlobalReport) callconv(.C) void;
-    // pub const EnumerateAdapters = *const fn(*Instance, ?*const EnumerateAdapterOptions, ?[*]Adapter) callconv(.C) usize;
+    // pub const GenerateReport = *const fn(*Instance, *GlobalReport) callconv(.c) void;
+    // pub const EnumerateAdapters = *const fn(*Instance, ?*const EnumerateAdapterOptions, ?[*]Adapter) callconv(.c) usize;
 };
 
 extern fn wgpuGetInstanceCapabilities(capabilities: *InstanceCapabilities) Status;
@@ -245,7 +245,7 @@ pub const Instance = opaque {
         wgpuInstanceProcessEvents(self);
     }
 
-    fn defaultAdapterCallback(status: RequestAdapterStatus, adapter: ?*Adapter, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void {
+    fn defaultAdapterCallback(status: RequestAdapterStatus, adapter: ?*Adapter, message: StringView, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void {
         const ud_response: *RequestAdapterResponse = @ptrCast(@alignCast(userdata1));
         ud_response.* = RequestAdapterResponse {
             .status = status,

--- a/src/log.zig
+++ b/src/log.zig
@@ -9,7 +9,7 @@ pub const LogLevel = enum(u32) {
     trace    = 0x00000005,
 };
 
-pub const LogCallback = *const fn(level: LogLevel, message: StringView, userdata: ?*anyopaque) callconv(.C) void;
+pub const LogCallback = *const fn(level: LogLevel, message: StringView, userdata: ?*anyopaque) callconv(.c) void;
 
 extern fn wgpuSetLogCallback(callback: LogCallback, userdata: ?*anyopaque) void;
 extern fn wgpuSetLogLevel(level: LogLevel) void;

--- a/src/misc.zig
+++ b/src/misc.zig
@@ -78,7 +78,7 @@ pub const FeatureName = enum(u32) {
 };
 
 pub const SupportedFeaturesProcs = struct {
-    pub const FreeMembers = *const fn(SupportedFeatures) callconv(.C) void;
+    pub const FreeMembers = *const fn(SupportedFeatures) callconv(.c) void;
 };
 
 extern fn wgpuSupportedFeaturesFreeMembers(supported_features: SupportedFeatures) void;

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -56,9 +56,9 @@ pub const PipelineLayoutDescriptor = extern struct {
 };
 
 pub const PipelineLayoutProcs = struct {
-    pub const SetLabel = *const fn(*PipelineLayout, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*PipelineLayout) callconv(.C) void;
-    pub const Release = *const fn(*PipelineLayout) callconv(.C) void;
+    pub const SetLabel = *const fn(*PipelineLayout, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*PipelineLayout) callconv(.c) void;
+    pub const Release = *const fn(*PipelineLayout) callconv(.c) void;
 };
 
 extern fn wgpuPipelineLayoutSetLabel(pipeline_layout: *PipelineLayout, label: StringView) void;
@@ -128,13 +128,13 @@ pub const CreateComputePipelineAsyncCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const ComputePipelineProcs = struct {
-    pub const GetBindGroupLayout = *const fn(*ComputePipeline, u32) callconv(.C) ?*BindGroupLayout;
-    pub const SetLabel = *const fn(*ComputePipeline, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*ComputePipeline) callconv(.C) void;
-    pub const Release = *const fn(*ComputePipeline) callconv(.C) void;
+    pub const GetBindGroupLayout = *const fn(*ComputePipeline, u32) callconv(.c) ?*BindGroupLayout;
+    pub const SetLabel = *const fn(*ComputePipeline, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*ComputePipeline) callconv(.c) void;
+    pub const Release = *const fn(*ComputePipeline) callconv(.c) void;
 };
 
 extern fn wgpuComputePipelineGetBindGroupLayout(compute_pipeline: *ComputePipeline, group_index: u32) ?*BindGroupLayout;
@@ -425,10 +425,10 @@ pub const RenderPipelineDescriptor = extern struct {
 };
 
 pub const RenderPipelineProcs = struct {
-    pub const GetBindGroupLayout = *const fn(*RenderPipeline, u32) callconv(.C) ?*BindGroupLayout;
-    pub const SetLabel = *const fn(*RenderPipeline, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*RenderPipeline) callconv(.C) void;
-    pub const Release = *const fn(*RenderPipeline) callconv(.C) void;
+    pub const GetBindGroupLayout = *const fn(*RenderPipeline, u32) callconv(.c) ?*BindGroupLayout;
+    pub const SetLabel = *const fn(*RenderPipeline, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*RenderPipeline) callconv(.c) void;
+    pub const Release = *const fn(*RenderPipeline) callconv(.c) void;
 };
 
 extern fn wgpuRenderPipelineGetBindGroupLayout(render_pipeline: *RenderPipeline, group_index: u32) ?*BindGroupLayout;
@@ -472,4 +472,4 @@ pub const CreateRenderPipelineAsyncCallback = *const fn(
     message: StringView,
     userdata1: ?*anyopaque,
     userdata2: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;

--- a/src/query_set.zig
+++ b/src/query_set.zig
@@ -49,12 +49,12 @@ pub const QuerySetDescriptor = extern struct {
 };
 
 pub const QuerySetProcs = struct {
-    pub const Destroy = *const fn(*QuerySet) callconv(.C) void;
-    pub const GetCount = *const fn(*QuerySet) callconv(.C) u32;
-    pub const GetType = *const fn(*QuerySet) callconv(.C) QueryType;
-    pub const SetLabel = *const fn(*QuerySet, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*QuerySet) callconv(.C) void;
-    pub const Release = *const fn(*QuerySet) callconv(.C) void;
+    pub const Destroy = *const fn(*QuerySet) callconv(.c) void;
+    pub const GetCount = *const fn(*QuerySet) callconv(.c) u32;
+    pub const GetType = *const fn(*QuerySet) callconv(.c) QueryType;
+    pub const SetLabel = *const fn(*QuerySet, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*QuerySet) callconv(.c) void;
+    pub const Release = *const fn(*QuerySet) callconv(.c) void;
 };
 
 extern fn wgpuQuerySetDestroy(query_set: *QuerySet) void;

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -38,19 +38,19 @@ pub const QueueWorkDoneCallbackInfo = extern struct {
     userdata2: ?*anyopaque = null,
 };
 
-pub const QueueWorkDoneCallback = *const fn(status: WorkDoneStatus, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const QueueWorkDoneCallback = *const fn(status: WorkDoneStatus, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 pub const QueueProcs = struct {
-    pub const OnSubmittedWorkDone = *const fn(*Queue, QueueWorkDoneCallbackInfo) callconv(.C) Future;
-    pub const SetLabel = *const fn(*Queue, StringView) callconv(.C) void;
-    pub const Submit = *const fn(*Queue, usize, [*]const *const CommandBuffer) callconv(.C) void;
-    pub const WriteBuffer = *const fn(*Queue, Buffer, u64, *const anyopaque, usize) callconv(.C) void;
-    pub const WriteTexture = *const fn(*Queue, *const TexelCopyTextureInfo, *const anyopaque, usize, *const TexelCopyBufferLayout, *const Extent3D) callconv(.C) void;
-    pub const AddRef = *const fn(*Queue) callconv(.C) void;
-    pub const Release = *const fn(*Queue) callconv(.C) void;
+    pub const OnSubmittedWorkDone = *const fn(*Queue, QueueWorkDoneCallbackInfo) callconv(.c) Future;
+    pub const SetLabel = *const fn(*Queue, StringView) callconv(.c) void;
+    pub const Submit = *const fn(*Queue, usize, [*]const *const CommandBuffer) callconv(.c) void;
+    pub const WriteBuffer = *const fn(*Queue, Buffer, u64, *const anyopaque, usize) callconv(.c) void;
+    pub const WriteTexture = *const fn(*Queue, *const TexelCopyTextureInfo, *const anyopaque, usize, *const TexelCopyBufferLayout, *const Extent3D) callconv(.c) void;
+    pub const AddRef = *const fn(*Queue) callconv(.c) void;
+    pub const Release = *const fn(*Queue) callconv(.c) void;
 
     // wgpu-native procs?
-    // pub const SubmitForIndex = *const fn(*Queue, usize, [*]const *const CommandBuffer) callconv(.C) SubmissionIndex;
+    // pub const SubmitForIndex = *const fn(*Queue, usize, [*]const *const CommandBuffer) callconv(.c) SubmissionIndex;
 };
 
 extern fn wgpuQueueOnSubmittedWorkDone(queue: *Queue, callback_info: QueueWorkDoneCallbackInfo) Future;

--- a/src/render_bundle.zig
+++ b/src/render_bundle.zig
@@ -22,24 +22,24 @@ pub const RenderBundleEncoderDescriptor = extern struct {
 };
 
 pub const RenderBundleEncoderProcs = struct {
-    pub const Draw = *const fn(*RenderBundleEncoder, u32, u32, u32, u32) callconv(.C) void;
-    pub const DrawIndexed = *const fn(*RenderBundleEncoder, u32, u32, u32, i32, u32) callconv(.C) void;
-    pub const DrawIndexedIndirect = *const fn(*RenderBundleEncoder, *Buffer, u64) callconv(.C) void;
-    pub const DrawIndirect = *const fn(*RenderBundleEncoder, *Buffer, u64) callconv(.C) void;
-    pub const Finish = *const fn(*RenderBundleEncoder, *const RenderBundleDescriptor) callconv(.C) ?*RenderBundle;
-    pub const InsertDebugMarker = *const fn(*RenderBundleEncoder, StringView) callconv(.C) void;
-    pub const PopDebugGroup = *const fn(*RenderBundleEncoder) callconv(.C) void;
-    pub const PushDebugGroup = *const fn(*RenderBundleEncoder, StringView) callconv(.C) void;
-    pub const SetBindGroup = *const fn(*RenderBundleEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.C) void;
-    pub const SetIndexBuffer = *const fn(*RenderBundleEncoder, *Buffer, IndexFormat, u64, u64) callconv(.C) void;
-    pub const SetLabel = *const fn(*RenderBundleEncoder, StringView) callconv(.C) void;
-    pub const SetPipeline = *const fn(*RenderBundleEncoder, *RenderPipeline) callconv(.C) void;
-    pub const SetVertexBuffer = *const fn(*RenderBundleEncoder, u32, *Buffer, u64, u64) callconv(.C) void;
-    pub const AddRef = *const fn(*RenderBundleEncoder) callconv(.C) void;
-    pub const Release = *const fn(*RenderBundleEncoder) callconv(.C) void;
+    pub const Draw = *const fn(*RenderBundleEncoder, u32, u32, u32, u32) callconv(.c) void;
+    pub const DrawIndexed = *const fn(*RenderBundleEncoder, u32, u32, u32, i32, u32) callconv(.c) void;
+    pub const DrawIndexedIndirect = *const fn(*RenderBundleEncoder, *Buffer, u64) callconv(.c) void;
+    pub const DrawIndirect = *const fn(*RenderBundleEncoder, *Buffer, u64) callconv(.c) void;
+    pub const Finish = *const fn(*RenderBundleEncoder, *const RenderBundleDescriptor) callconv(.c) ?*RenderBundle;
+    pub const InsertDebugMarker = *const fn(*RenderBundleEncoder, StringView) callconv(.c) void;
+    pub const PopDebugGroup = *const fn(*RenderBundleEncoder) callconv(.c) void;
+    pub const PushDebugGroup = *const fn(*RenderBundleEncoder, StringView) callconv(.c) void;
+    pub const SetBindGroup = *const fn(*RenderBundleEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.c) void;
+    pub const SetIndexBuffer = *const fn(*RenderBundleEncoder, *Buffer, IndexFormat, u64, u64) callconv(.c) void;
+    pub const SetLabel = *const fn(*RenderBundleEncoder, StringView) callconv(.c) void;
+    pub const SetPipeline = *const fn(*RenderBundleEncoder, *RenderPipeline) callconv(.c) void;
+    pub const SetVertexBuffer = *const fn(*RenderBundleEncoder, u32, *Buffer, u64, u64) callconv(.c) void;
+    pub const AddRef = *const fn(*RenderBundleEncoder) callconv(.c) void;
+    pub const Release = *const fn(*RenderBundleEncoder) callconv(.c) void;
 
     // wgpu-native procs?
-    // pub const SetPushConstants = *const fn(*RenderBundleEncoder, ShaderStage, u32, u32, *const anyopaque) callconv(.C) void;
+    // pub const SetPushConstants = *const fn(*RenderBundleEncoder, ShaderStage, u32, u32, *const anyopaque) callconv(.c) void;
 };
 
 extern fn wgpuRenderBundleEncoderDraw(render_bundle_encoder: *RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void;
@@ -125,9 +125,9 @@ pub const RenderBundleDescriptor = extern struct {
 };
 
 pub const RenderBundleProcs = struct {
-    pub const SetLabel = *const fn(*RenderBundle, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*RenderBundle) callconv(.C) void;
-    pub const Release = *const fn(*RenderBundle) callconv(.C) void;
+    pub const SetLabel = *const fn(*RenderBundle, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*RenderBundle) callconv(.c) void;
+    pub const Release = *const fn(*RenderBundle) callconv(.c) void;
 };
 
 extern fn wgpuRenderBundleSetLabel(render_bundle: *RenderBundle, label: StringView) void;

--- a/src/sampler.zig
+++ b/src/sampler.zig
@@ -56,9 +56,9 @@ pub const SamplerDescriptor = extern struct {
 };
 
 pub const SamplerProcs = struct {
-    pub const SetLabel = *const fn(*Sampler, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*Sampler) callconv(.C) void;
-    pub const Release = *const fn(*Sampler) callconv(.C) void;
+    pub const SetLabel = *const fn(*Sampler, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*Sampler) callconv(.c) void;
+    pub const Release = *const fn(*Sampler) callconv(.c) void;
 };
 
 extern fn wgpuSamplerSetLabel(sampler: *Sampler, label: StringView) void;

--- a/src/shader.zig
+++ b/src/shader.zig
@@ -150,7 +150,7 @@ pub const CompilationInfo = extern struct {
     messages: [*]const CompilationMessage,
 };
 
-pub const CompilationInfoCallback = *const fn(status: CompilationInfoRequestStatus, compilationInfo: ?*const CompilationInfo, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.C) void;
+pub const CompilationInfoCallback = *const fn(status: CompilationInfoRequestStatus, compilationInfo: ?*const CompilationInfo, userdata1: ?*anyopaque, userdata2: ?*anyopaque) callconv(.c) void;
 
 pub const CompilationInfoCallbackInfo = extern struct {
     next_in_chain: ?*const ChainedStruct = null,
@@ -164,10 +164,10 @@ pub const CompilationInfoCallbackInfo = extern struct {
 };
 
 pub const ShaderModuleProcs = struct {
-    pub const GetCompilationInfo = *const fn(*ShaderModule, CompilationInfoCallbackInfo) callconv(.C) Future;
-    pub const SetLabel = *const fn(*ShaderModule, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*ShaderModule) callconv(.C) void;
-    pub const Release = *const fn(*ShaderModule) callconv(.C) void;
+    pub const GetCompilationInfo = *const fn(*ShaderModule, CompilationInfoCallbackInfo) callconv(.c) Future;
+    pub const SetLabel = *const fn(*ShaderModule, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*ShaderModule) callconv(.c) void;
+    pub const Release = *const fn(*ShaderModule) callconv(.c) void;
 };
 
 extern fn wgpuShaderModuleGetCompilationInfo(shader_module: *ShaderModule, callback_info: CompilationInfoCallbackInfo) Future;

--- a/src/surface.zig
+++ b/src/surface.zig
@@ -274,7 +274,7 @@ pub const SurfaceConfiguration = extern struct {
 };
 
 pub const SurfaceCapabilitiesProcs = struct {
-    pub const FreeMembers = *const fn(SurfaceCapabilities) callconv(.C) void;
+    pub const FreeMembers = *const fn(SurfaceCapabilities) callconv(.c) void;
 };
 
 extern fn wgpuSurfaceCapabilitiesFreeMembers(surface_capabilities: SurfaceCapabilities) void;
@@ -348,14 +348,14 @@ pub const SurfaceTexture = extern struct {
 };
 
 pub const SurfaceProcs = struct {
-    pub const Configure = *const fn(*Surface, *const SurfaceConfiguration) callconv(.C) void;
-    pub const GetCapabilities = *const fn(*Surface, *Adapter, *SurfaceCapabilities) callconv(.C) Status;
-    pub const GetCurrentTexture = *const fn(*Surface, *SurfaceTexture) callconv(.C) void;
-    pub const Present = *const fn(*Surface) callconv(.C) Status;
+    pub const Configure = *const fn(*Surface, *const SurfaceConfiguration) callconv(.c) void;
+    pub const GetCapabilities = *const fn(*Surface, *Adapter, *SurfaceCapabilities) callconv(.c) Status;
+    pub const GetCurrentTexture = *const fn(*Surface, *SurfaceTexture) callconv(.c) void;
+    pub const Present = *const fn(*Surface) callconv(.c) Status;
     pub const SetLabel = *const fn(*Surface, StringView) void;
-    pub const Unconfigure = *const fn(*Surface) callconv(.C) void;
-    pub const AddRef = *const fn(*Surface) callconv(.C) void;
-    pub const Release = *const fn(*Surface) callconv(.C) void;
+    pub const Unconfigure = *const fn(*Surface) callconv(.c) void;
+    pub const AddRef = *const fn(*Surface) callconv(.c) void;
+    pub const Release = *const fn(*Surface) callconv(.c) void;
 };
 
 extern fn wgpuSurfaceConfigure(surface: *Surface, config: *const SurfaceConfiguration) void;

--- a/src/texture.zig
+++ b/src/texture.zig
@@ -154,9 +154,9 @@ pub const TextureViewDescriptor = extern struct {
 };
 
 pub const TextureViewProcs = struct {
-    pub const SetLabel = *const fn(*TextureView, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*TextureView) callconv(.C) void;
-    pub const Release = *const fn(*TextureView) callconv(.C) void;
+    pub const SetLabel = *const fn(*TextureView, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*TextureView) callconv(.c) void;
+    pub const Release = *const fn(*TextureView) callconv(.c) void;
 };
 
 extern fn wgpuTextureViewSetLabel(texture_view: *TextureView, label: StringView) void;
@@ -256,19 +256,19 @@ pub const TextureDescriptor = extern struct {
 };
 
 pub const TextureProcs = struct {
-    pub const CreateView = *const fn(*Texture, ?*const TextureViewDescriptor) callconv(.C) ?*TextureView;
-    pub const Destroy = *const fn(*Texture) callconv(.C) void;
-    pub const GetDepthOrArrayLayers = *const fn(*Texture) callconv(.C) u32;
-    pub const GetDimension = *const fn(*Texture) callconv(.C) TextureDimension;
-    pub const GetFormat = *const fn(*Texture) callconv(.C) TextureFormat;
-    pub const GetHeight = *const fn(*Texture) callconv(.C) u32;
-    pub const GetMipLevelCount = *const fn(*Texture) callconv(.C) u32;
-    pub const GetSampleCount = *const fn(*Texture) callconv(.C) u32;
-    pub const GetUsage = *const fn(*Texture) callconv(.C) TextureUsage;
-    pub const GetWidth = *const fn(*Texture) callconv(.C) u32;
-    pub const SetLabel = *const fn(*Texture, StringView) callconv(.C) void;
-    pub const AddRef = *const fn(*Texture) callconv(.C) void;
-    pub const Release = *const fn(*Texture) callconv(.C) void;
+    pub const CreateView = *const fn(*Texture, ?*const TextureViewDescriptor) callconv(.c) ?*TextureView;
+    pub const Destroy = *const fn(*Texture) callconv(.c) void;
+    pub const GetDepthOrArrayLayers = *const fn(*Texture) callconv(.c) u32;
+    pub const GetDimension = *const fn(*Texture) callconv(.c) TextureDimension;
+    pub const GetFormat = *const fn(*Texture) callconv(.c) TextureFormat;
+    pub const GetHeight = *const fn(*Texture) callconv(.c) u32;
+    pub const GetMipLevelCount = *const fn(*Texture) callconv(.c) u32;
+    pub const GetSampleCount = *const fn(*Texture) callconv(.c) u32;
+    pub const GetUsage = *const fn(*Texture) callconv(.c) TextureUsage;
+    pub const GetWidth = *const fn(*Texture) callconv(.c) u32;
+    pub const SetLabel = *const fn(*Texture, StringView) callconv(.c) void;
+    pub const AddRef = *const fn(*Texture) callconv(.c) void;
+    pub const Release = *const fn(*Texture) callconv(.c) void;
 };
 
 extern fn wgpuTextureCreateView(texture: *Texture, descriptor: ?*const TextureViewDescriptor) ?*TextureView;


### PR DESCRIPTION
- Updated all 221 occurrences of callconv(.C) to callconv(.c)
- Required for Zig 0.14+ which changed calling convention syntax
- Fixes compilation errors with Zig 0.15.2